### PR TITLE
Removing JSON dependency on probe code.

### DIFF
--- a/ProbeGenerator/pom.xml
+++ b/ProbeGenerator/pom.xml
@@ -15,12 +15,6 @@
   		<version>4.11</version>
   		<scope>test</scope>
   	</dependency>
-  	<dependency>
-  		<groupId>net.sf.json-lib</groupId>
-  		<artifactId>json-lib</artifactId>
-  		<version>2.4</version>
-  		<classifier>jdk15</classifier>
-  	</dependency>
   </dependencies>
 
 </project>

--- a/ProbeGenerator/src/main/java/ws/argo/ProbeGenerator/Probe.java
+++ b/ProbeGenerator/src/main/java/ws/argo/ProbeGenerator/Probe.java
@@ -19,9 +19,6 @@ package ws.argo.ProbeGenerator;
 import java.util.ArrayList;
 import java.util.UUID;
 
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-
 public class Probe {
 
 	public static final String PROBE_GENERTOR_CONTRACT_ID= "urn:uuid:55f1fecc-bfed-4be0-926b-b36a138a9943";
@@ -75,32 +72,6 @@ public class Probe {
 		buf.append("</probe>\n\n");
 		
 		return buf.toString();
-	}
-	
-	// Do we need to cook this up as JSON?
-	// The multicast responder doens't care and XML is easy enough to gin up as text from anywhere
-	public JSONObject asJSONObject() {
-		JSONObject json = new JSONObject();
-		
-		json.put("probeID", probeID);
-		json.put("contractID", PROBE_GENERTOR_CONTRACT_ID);
-		json.put("respondTo", respondToURL);
-		json.put("respondToPayloadType", respondToPayloadType);
-		
-		JSONArray contractIDs = new JSONArray();
-		
-		for (String contractID : serviceContractIDs ) {
-			contractIDs.add(contractID);
-		}
-		
-		json.put("serviceContractIDs", contractIDs);
-		
-		return json;
-	}
-	
-	public String asJSON() {
-		JSONObject json = asJSONObject();
-		return json.toString(4);
 	}
 	
 }

--- a/ProbeGenerator/src/test/java/net/di2e/rtsd/ProbeGenerator/ProbeGeneratorTest.java
+++ b/ProbeGenerator/src/test/java/net/di2e/rtsd/ProbeGenerator/ProbeGeneratorTest.java
@@ -31,20 +31,6 @@ public class ProbeGeneratorTest {
 	}
 	
 	@Test
-	public void testProbeGeneratorJSON() throws IOException {
-		
-//		10.12.128.136
-		
-		String hostIPAddr = InetAddress.getLocalHost().getHostAddress();
-		
-		Probe probe = new Probe("http://"+hostIPAddr+":8080/AsynchListener/api/responseHandler/probeResponse", Probe.JSON);
-		
-		probe.addServiceContractID("uuid:03d55093-a954-4667-b682-8116c417925d");	
-		
-		System.out.println(probe.asJSON());
-	}
-	
-	@Test
 	public void testProbeGeneratorAllService() throws IOException {
 		String hostIPAddr = InetAddress.getLocalHost().getHostAddress();
 		Probe probe = new Probe("http://"+hostIPAddr+":8080/AsynchListener/api/responseHandler/probeResponse", Probe.JSON);


### PR DESCRIPTION
The net.sf.json-lib:json-lib library has a lot of extra dependencies that complicates trying to embed this component into certain environments.  I'm taking it out here as it seems like from the inline comments that JSON isn't fully supported yet. My suggestion would be to take this out now and then during the protocol enhancement officially add in JSON support and use a lighter library (like org.json:json) which does not have any external dependencies.

Definitely open for discussion though :)