### PR TITLE
Fixes #98 by allowing the keystore/truststore to not be set in the cl…

### DIFF
--- a/CLClient/src/main/java/ws/argo/CLClient/config/ClientConfiguration.java
+++ b/CLClient/src/main/java/ws/argo/CLClient/config/ClientConfiguration.java
@@ -16,6 +16,7 @@ import javax.ws.rs.client.WebTarget;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.annotation.Immutable;
 import org.glassfish.grizzly.Grizzly;
 import org.glassfish.grizzly.ssl.SSLContextConfigurator;
@@ -214,17 +215,21 @@ public class ClientConfiguration extends ResolvingXMLConfiguration {
     _ksPassword = _config.getString("keystorePassword");
     _truststore = _config.getString("truststoreFilename");
     _tsPassword = _config.getString("truststorePassword");
-
+    
     _sslContextConfigurator = new SSLContextConfigurator();
 
-    // set up security context contains listener self-signed certificate
-    _sslContextConfigurator.setKeyStoreFile(getKeystore());
-    _sslContextConfigurator.setKeyStorePass(getKSPassword());
-    // contains listener self-signed certificate
-    _sslContextConfigurator.setTrustStoreFile(getTruststore());
-    _sslContextConfigurator.setTrustStorePass(getTSPassword());
+    if ( StringUtils.isNotEmpty( _keystore ) && StringUtils.isNotEmpty(_ksPassword ) && StringUtils.isNotEmpty( _truststore ) && StringUtils.isNotEmpty( _tsPassword ) ){
+        // set up security context contains listener self-signed certificate
+        _sslContextConfigurator.setKeyStoreFile(getKeystore());
+        _sslContextConfigurator.setKeyStorePass(getKSPassword());
+        // contains listener self-signed certificate
+        _sslContextConfigurator.setTrustStoreFile(getTruststore());
+        _sslContextConfigurator.setTrustStorePass(getTSPassword());
 
-    validateKeystoreConfiguration();
+        validateKeystoreConfiguration();
+    }else{
+    	Console.warn( "***** WARNING: KeyStore and TrustStore were not set.  You will not be able to use SSL/TLS communications.  Update the clientConfig.xml file if SSL/TLS is needed *****" );
+    }
   }
 
   private void initializeURLs() {


### PR DESCRIPTION
…ient and just prints out a warning mesage stating that SSL/TLS will not be used when the probe client starts. 

This allows the probe to be started with the default configuration, helping people just test it out or use it in their environment if it doesn't require SSL/TLS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/di2e/argo/99)
<!-- Reviewable:end -->
