### PR TITLE
Fixes Argo issue #100 where the default configuration is not working …

### DIFF
--- a/CLClient/src/main/java/ws/argo/CLClient/listener/ResponseListener.java
+++ b/CLClient/src/main/java/ws/argo/CLClient/listener/ResponseListener.java
@@ -63,7 +63,7 @@ public class ResponseListener {
       LOGGER.warning("Issues finding ip address of locahost.  Using string 'localhost' for listener address binding");
       addr = "localhost";
     }
-    return UriBuilder.fromUri("http://" + addr + "/").port(4005).build();
+    return UriBuilder.fromUri("http://" + addr ).port(4005).build();
   }
 
   /**


### PR DESCRIPTION
…because there is an extra / when it creates the default listenURL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/di2e/argo/103)
<!-- Reviewable:end -->
