### PR TITLE
Fixed the javadoc build issues

### DIFF
--- a/PluginFramework/src/main/java/ws/argo/plugin/transport/sender/Transport.java
+++ b/PluginFramework/src/main/java/ws/argo/plugin/transport/sender/Transport.java
@@ -38,16 +38,16 @@ public interface Transport {
    * @param networkInterface name of the network interface
    * @throws TransportConfigException if something goes wrong
    */
-  public void initialize(Properties p, String networkInterface) throws TransportConfigException;
+  void initialize(Properties p, String networkInterface) throws TransportConfigException;
 
   /**
    * Actually send the probe out on transport mechanism.
    * 
    * @param probe the Probe instance that has been pre-configured
-   * @throws ProbeSenderException if something bad happened when sending the
+   * @throws TransportException if something bad happened when sending the
    *           probe
    */
-  public void sendProbe(Probe probe) throws TransportException;
+  void sendProbe(Probe probe) throws TransportException;
 
   /**
    * Return the maximum payload size that this transport can handle. For
@@ -58,20 +58,20 @@ public interface Transport {
    * 
    * @return max payload size in bytes
    */
-  public int maxPayloadSize();
+  int maxPayloadSize();
 
   /**
    * Return the name of the network interface associated with this transport.
    * 
    * @return the name of the network interface associated with this transport
    */
-  public String getNetworkInterfaceName();
+  String getNetworkInterfaceName();
 
   /**
    * Close the transport.
    * 
-   * @throws ProbeSenderException if something bad happened
+   * @throws TransportException if something bad happened
    */
-  public void close() throws TransportException;
+  void close() throws TransportException;
 
 }

--- a/ProbeSender/src/main/java/ws/argo/probe/ProbeSender.java
+++ b/ProbeSender/src/main/java/ws/argo/probe/ProbeSender.java
@@ -90,7 +90,7 @@ public class ProbeSender {
   /**
    * Close the underlying transport if necessary.
    * 
-   * @throws ProbeSenderException if something goes wrong
+   * @throws TransportException if something goes wrong
    */
   public void close() throws TransportException {
     probeTransport.close();

--- a/ProbeSender/src/main/java/ws/argo/transport/probe/standard/MulticastTransport.java
+++ b/ProbeSender/src/main/java/ws/argo/transport/probe/standard/MulticastTransport.java
@@ -220,7 +220,7 @@ public class MulticastTransport implements Transport {
    * Actually send the probe out on the wire.
    * 
    * @param probe the Probe instance that has been pre-configured
-   * @throws ProbeSenderException if something bad happened when sending the
+   * @throws TransportException if something bad happened when sending the
    *           probe
    */
   @Override

--- a/Responder/ResponderDaemon/pom.xml
+++ b/Responder/ResponderDaemon/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>ws.argo.responder</groupId>
@@ -242,7 +242,6 @@
       </plugin>
 
 
-
       <!-- Do not put distribution in a repo -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -265,6 +264,31 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.3</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <excludePackageNames>ws.argo.responder.plugin.configfile.xml.*</excludePackageNames>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>rpm</id>
       <build>

--- a/Responder/ResponderDaemon/src/main/java/ws/argo/responder/Responder.java
+++ b/Responder/ResponderDaemon/src/main/java/ws/argo/responder/Responder.java
@@ -136,7 +136,7 @@ public class Responder implements ProbeProcessor {
   /**
    * Create a new instance of a Responder.
    * 
-   * @param cliValues - the list of command line arguments
+   * @param config  - the list of command line arguments
    */
   public Responder(ResponderConfiguration config) {
     this._config = config;

--- a/pom.xml
+++ b/pom.xml
@@ -179,13 +179,16 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.9.1</version>
+						<version>2.10.3</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
 								<goals>
 									<goal>jar</goal>
 								</goals>
+								<configuration> <!-- add this to disable checking -->
+									<additionalparam>-Xdoclint:none</additionalparam>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
The javadoc build issues where the normal “need to fix” stuff you
normally find.  Plus I needed to kill the clint processing for the
java-gen java source files, specifically all the XML class generation
from xsd files.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/di2e/argo/109)

<!-- Reviewable:end -->
